### PR TITLE
Fixes python 36 installation by removing non-ascii chars from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ client.set_cache(2, 10)
 
 # Same as the above mode, but allow an expired cached value to be used if the server 
 # is unavailable.
-# Cache Then Server Fallback on Expired Cache for 15 minutes
+# Cache Then Server Fallback on Expired Cache for 15 minutes
 client.set_cache(3, 15)
 
 # Clear all cached values immediately

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="secret-server-sdk-client",
-    version="1.0",
+    version="1.1",
     author="Paulo Dorado",
     author_email="support@thycotic.com",
     description="Thycotic python client that uses the Thycotic SDK to get secrets from secret server",


### PR DESCRIPTION
Solves the installation problem on python36, which is caused by non-ASCII characters in README.md file, which is loaded in setup.py for long_description.

Find below output of the error and solution from my branch (CentOS 7 container with python36 installed).

```
[root@d52dad224329 /]# pip3 install secret-server-sdk-client
Collecting secret-server-sdk-client
  Downloading https://files.pythonhosted.org/packages/18/21/263f270691561f659ec8295efe40fd38a10970b05ad67251426bdfdd6566/secret-server-sdk-client-1.0.tar.gz
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-5w40mpg3/secret-server-sdk-client/setup.py", line 4, in <module>
        long_description = fh.read()
      File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3653: ordinal not in range(128)
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-5w40mpg3/secret-server-sdk-client/
```

The following non-ascii chars were removed and the installation is successfull now.
```
~ $ pcregrep --color='auto' -n "[^\x00-\x7F]" README.md
143:# Cache��Then��Server��Fallback��on��Expired��Cache for 15 minutes
```

Test output after implementing the solution
```
[root@d52dad224329 /]# pip3 install git+https://github.com/khnazaretyan/secret-server-python.git@fix-python36_install_ascii
Collecting git+https://github.com/khnazaretyan/secret-server-python.git@fix-python36_install_ascii
  Cloning https://github.com/khnazaretyan/secret-server-python.git (to revision fix-python36_install_ascii) to /tmp/pip-req-build-br2vcoqf
  Running command git clone -q https://github.com/khnazaretyan/secret-server-python.git /tmp/pip-req-build-br2vcoqf
  Running command git checkout -b fix-python36_install_ascii --track origin/fix-python36_install_ascii
  Switched to a new branch 'fix-python36_install_ascii'
  Branch fix-python36_install_ascii set up to track remote branch fix-python36_install_ascii from origin.
Installing collected packages: secret-server-sdk-client
  Running setup.py install for secret-server-sdk-client ... done
Successfully installed secret-server-sdk-client-1.1
[root@d52dad224329 /]#
[root@d52dad224329 /]#
[root@d52dad224329 /]#
[root@d52dad224329 /]# pip3 show secret-server-sdk-client
Name: secret-server-sdk-client
Version: 1.1
Summary: Thycotic python client that uses the Thycotic SDK to get secrets from secret server
Home-page: https://github.com/thycotic/secret-server-python
Author: Paulo Dorado
Author-email: support@thycotic.com
License: UNKNOWN
Location: /usr/local/lib/python3.6/site-packages
Requires:
Required-by:
```

The minor version change is accomplished to push the package back to PyPI.

Note:
**After merging this PR please also push the latest PyPI package accordingly to enable direct pip installation**